### PR TITLE
fixed program transmit protection for overlong programs

### DIFF
--- a/GlowSequencer/Usb/CommunicationUtility.cs
+++ b/GlowSequencer/Usb/CommunicationUtility.cs
@@ -28,7 +28,7 @@ namespace GlowSequencer.Usb
                 }
                 set
                 {
-                    if(command == 0x02 && value < 16384)
+                    if(command is 0x03 or 0x02 && value < 16384)
                     {
                         throw new ArgumentOutOfRangeException("Address must be greater than 0x0040 (16384) for command 0x02");
                     }


### PR DESCRIPTION
A small addition to prevent potential mistakes while transmitting too long programs.

Previous tests only resulted in writing the program if 0x03 and 0x02 were used in combination.
It could be the case that 0x03 erases previous data before 0x02 writes new bytes. The microchip documentation mentions erasing in 64-byte chunks, which would align with one 0x03 call before four 0x02 calls (which each writes 16 bytes).